### PR TITLE
update public date on oracle flaws to be 3rd Tuesday from Apr 2022

### DIFF
--- a/advisory_parser/__init__.py
+++ b/advisory_parser/__init__.py
@@ -5,4 +5,4 @@
 from .parser import Parser
 
 
-__version__ = "1.12"
+__version__ = "1.13"

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requires = ["beautifulsoup4>=4.0.0", "cvss>=2.0"]
 
 setup(
     name="advisory-parser",
-    version="1.12",
+    version="1.13",
     description="Security flaw parser for upstream security advisories",
     long_description=description,
     url="https://github.com/RedHatProductSecurity/advisory-parser",

--- a/tests/test_mysql_parser.py
+++ b/tests/test_mysql_parser.py
@@ -8,26 +8,40 @@ try:
 except ImportError:
     from mock import patch
 
-from advisory_parser.parsers.mysql import parse_mysql_advisory, _nearest_tuesday
+from advisory_parser.parsers.mysql import parse_mysql_advisory, _nearest_tuesday, _third_tuesday
 
 
 @pytest.mark.parametrize(
     "year, month, day, expected_date",
     [
-        (2017, "jul", 3, datetime(2017, 7, 4)),
-        (2017, "jul", 4, datetime(2017, 7, 4)),  # Tuesday
-        (2017, "jul", 5, datetime(2017, 7, 4)),
-        (2017, "jul", 6, datetime(2017, 7, 4)),
-        (2017, "jul", 7, datetime(2017, 7, 4)),
-        (2017, "jul", 8, datetime(2017, 7, 11)),
-        (2017, "jul", 9, datetime(2017, 7, 11)),
-        (2017, "jul", 10, datetime(2017, 7, 11)),
-        (2017, "jul", 11, datetime(2017, 7, 11)),  # Tuesday
-        (2017, "jul", 12, datetime(2017, 7, 11)),
+        (2017, 7, 3, datetime(2017, 7, 4)),
+        (2017, 7, 4, datetime(2017, 7, 4)),  # Tuesday
+        (2017, 7, 5, datetime(2017, 7, 4)),
+        (2017, 7, 6, datetime(2017, 7, 4)),
+        (2017, 7, 7, datetime(2017, 7, 4)),
+        (2017, 7, 8, datetime(2017, 7, 11)),
+        (2017, 7, 9, datetime(2017, 7, 11)),
+        (2017, 7, 10, datetime(2017, 7, 11)),
+        (2017, 7, 11, datetime(2017, 7, 11)),  # Tuesday
+        (2017, 7, 12, datetime(2017, 7, 11)),
     ],
 )
 def test_nearest_tuesday(year, month, day, expected_date):
     assert expected_date == _nearest_tuesday(year, month, day)
+
+
+@pytest.mark.parametrize(
+    "year, month, expected_date",
+    [
+        (2017, 7, datetime(2017, 7, 18).date()),
+        (2024, 7, datetime(2024, 7, 16).date()),
+        (2024, 10, datetime(2024, 10, 15).date()),
+        (2025, 1, datetime(2025, 1, 21).date()),
+        (2025, 4, datetime(2025, 4, 15).date()),
+    ],
+)
+def test_third_tuesday(year, month, expected_date):
+    assert expected_date == _third_tuesday(year, month)
 
 
 @patch("advisory_parser.parsers.mysql.get_request")


### PR DESCRIPTION
Oracle critical patch updates are now done on the 3rd Tuesday of the month.

"Critical Patch Updates provide security patches for supported Oracle on-premises products. They are available to customers with valid support contracts. Starting in April 2022, Critical Patch Updates are released on the third Tuesday of January, April, July, and October (They were previously published on the Tuesday closest to the 17th day of January, April, July, and October). The next four dates are:

    16 July 2024
    15 October 2024
    21 January 2025
    15 April 2025
"

See https://www.oracle.com/security-alerts/